### PR TITLE
net: mctp: usb: Fix In Transfer Parsing

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -13456,6 +13456,7 @@ L:	netdev@vger.kernel.org
 S:	Maintained
 F:	Documentation/networking/mctp.rst
 F:	drivers/net/mctp/
+F:	drivers/usb/gadget/function/f_mctp.c
 F:	include/linux/usb/mctp-usb.h
 F:	include/net/mctp.h
 F:	include/net/mctpdevice.h

--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -13456,6 +13456,7 @@ L:	netdev@vger.kernel.org
 S:	Maintained
 F:	Documentation/networking/mctp.rst
 F:	drivers/net/mctp/
+F:	include/linux/usb/mctp-usb.h
 F:	include/net/mctp.h
 F:	include/net/mctpdevice.h
 F:	include/net/netns/mctp.h

--- a/drivers/net/mctp/Kconfig
+++ b/drivers/net/mctp/Kconfig
@@ -42,6 +42,16 @@ config MCTP_TRANSPORT_I3C
 	  A MCTP protocol network device is created for each I3C bus
 	  having a "mctp-controller" devicetree property.
 
+config MCTP_TRANSPORT_USB
+	tristate "MCTP USB transport (EXPERIMENTAL)"
+	depends on USB
+	help
+	  Provides a driver to access MCTP devices over USB transport,
+	  defined by DMTF specification DSP0283.
+
+	  This driver is current experimental: it has not been verified against
+	  other MCTP-over-USB implementations.
+
 endmenu
 
 endif

--- a/drivers/net/mctp/Makefile
+++ b/drivers/net/mctp/Makefile
@@ -1,3 +1,4 @@
 obj-$(CONFIG_MCTP_SERIAL) += mctp-serial.o
 obj-$(CONFIG_MCTP_TRANSPORT_I2C) += mctp-i2c.o
 obj-$(CONFIG_MCTP_TRANSPORT_I3C) += mctp-i3c.o
+obj-$(CONFIG_MCTP_TRANSPORT_USB) += mctp-usb.o

--- a/drivers/net/mctp/mctp-usb.c
+++ b/drivers/net/mctp/mctp-usb.c
@@ -1,0 +1,350 @@
+// SPDX-License-Identifier: GPL-2.0+
+/*
+ * mctp-usb.c - MCTP-over-USB (DMTF DSP0283) transport binding driver.
+ *
+ * Copyright (C) 2024 Code Construct Pty Ltd
+ */
+
+#include <linux/module.h>
+#include <linux/netdevice.h>
+#include <linux/usb.h>
+#include <linux/usb/mctp-usb.h>
+
+#include <net/mctp.h>
+
+#include <uapi/linux/if_arp.h>
+
+struct mctp_usb {
+	struct usb_device *usbdev;
+	struct usb_interface *intf;
+
+	struct net_device *netdev;
+
+	__u8 ep_in;
+	__u8 ep_out;
+
+	struct urb *tx_urb;
+	struct urb *rx_urb;
+};
+
+static void mctp_usb_stat_tx_dropped(struct net_device *dev)
+{
+	struct pcpu_dstats *dstats = this_cpu_ptr(dev->dstats);
+
+	u64_stats_update_begin(&dstats->syncp);
+	u64_stats_inc(&dstats->tx_drops);
+	u64_stats_update_end(&dstats->syncp);
+}
+
+static void mctp_usb_stat_tx_done(struct net_device *dev, unsigned int len)
+{
+	struct pcpu_dstats *dstats = this_cpu_ptr(dev->dstats);
+
+	u64_stats_update_begin(&dstats->syncp);
+	u64_stats_inc(&dstats->tx_packets);
+	u64_stats_add(&dstats->tx_bytes, len);
+	u64_stats_update_end(&dstats->syncp);
+}
+
+static void mctp_usb_out_complete(struct urb *urb)
+{
+	struct sk_buff *skb = urb->context;
+	struct net_device *netdev = skb->dev;
+	struct mctp_usb *mctp_usb = netdev_priv(netdev);
+	int status;
+
+	status = urb->status;
+
+	switch (status) {
+	case -ENOENT:
+	case -ECONNRESET:
+	case -ESHUTDOWN:
+	case -EPROTO:
+		mctp_usb_stat_tx_dropped(netdev);
+		break;
+	case 0:
+		mctp_usb_stat_tx_done(netdev, skb->len);
+		netif_wake_queue(netdev);
+		consume_skb(skb);
+		return;
+	default:
+		dev_err(&mctp_usb->usbdev->dev, "%s: urb status: %d\n",
+			__func__, status);
+		mctp_usb_stat_tx_dropped(netdev);
+	}
+
+	kfree_skb(skb);
+}
+
+static netdev_tx_t mctp_usb_start_xmit(struct sk_buff *skb,
+				       struct net_device *dev)
+{
+	struct mctp_usb *mctp_usb = netdev_priv(dev);
+	struct mctp_usb_hdr *hdr;
+	unsigned int plen;
+	struct urb *urb;
+	int rc;
+
+	plen = skb->len;
+
+	if (plen + sizeof(*hdr) > MCTP_USB_XFER_SIZE)
+		goto err_drop;
+
+	hdr = skb_push(skb, sizeof(*hdr));
+	if (!hdr)
+		goto err_drop;
+
+	hdr->id = cpu_to_le16(MCTP_USB_DMTF_ID);
+	hdr->rsvd = 0;
+	hdr->len = plen + sizeof(*hdr);
+
+	urb = mctp_usb->tx_urb;
+
+	usb_fill_bulk_urb(urb, mctp_usb->usbdev,
+			  usb_sndbulkpipe(mctp_usb->usbdev, mctp_usb->ep_out),
+			  skb->data, skb->len,
+			  mctp_usb_out_complete, skb);
+
+	rc = usb_submit_urb(urb, GFP_ATOMIC);
+	if (rc)
+		goto err_drop;
+	else
+		netif_stop_queue(dev);
+
+	return NETDEV_TX_OK;
+
+err_drop:
+	mctp_usb_stat_tx_dropped(dev);
+	kfree_skb(skb);
+	return NETDEV_TX_OK;
+}
+
+static void mctp_usb_in_complete(struct urb *urb);
+
+static int mctp_usb_rx_queue(struct mctp_usb *mctp_usb)
+{
+	struct sk_buff *skb;
+	int rc;
+
+	skb = netdev_alloc_skb(mctp_usb->netdev, MCTP_USB_XFER_SIZE);
+	if (!skb)
+		return -ENOMEM;
+
+	usb_fill_bulk_urb(mctp_usb->rx_urb, mctp_usb->usbdev,
+			  usb_rcvbulkpipe(mctp_usb->usbdev, mctp_usb->ep_in),
+			  skb->data, MCTP_USB_XFER_SIZE,
+			  mctp_usb_in_complete, skb);
+
+	rc = usb_submit_urb(mctp_usb->rx_urb, GFP_ATOMIC);
+	if (rc) {
+		dev_err(&mctp_usb->usbdev->dev, "%s: usb_submit_urb: %d\n",
+			__func__, rc);
+		kfree_skb(skb);
+	}
+
+	return rc;
+}
+
+static void mctp_usb_in_complete(struct urb *urb)
+{
+	struct sk_buff *skb = urb->context;
+	struct net_device *netdev = skb->dev;
+	struct pcpu_dstats *dstats = this_cpu_ptr(netdev->dstats);
+	struct mctp_usb *mctp_usb = netdev_priv(netdev);
+	struct mctp_skb_cb *cb;
+	unsigned int len;
+	int status;
+
+	status = urb->status;
+
+	switch (status) {
+	case -ENOENT:
+	case -ECONNRESET:
+	case -ESHUTDOWN:
+	case -EPROTO:
+		kfree_skb(skb);
+		return;
+	case 0:
+		break;
+	default:
+		dev_err(&mctp_usb->usbdev->dev, "%s: urb status: %d\n",
+			__func__, status);
+		kfree_skb(skb);
+		return;
+	}
+
+	len = urb->actual_length;
+	__skb_put(skb, len);
+
+	while (skb) {
+		struct sk_buff *skb2 = NULL;
+		struct mctp_usb_hdr *hdr;
+
+		hdr = skb_pull(skb, sizeof(*hdr));
+		if (!hdr)
+			break;
+
+		if (le16_to_cpu(hdr->id) != MCTP_USB_DMTF_ID) {
+			dev_dbg(&mctp_usb->usbdev->dev, "%s: invalid id %04x\n",
+				__func__, le16_to_cpu(hdr->id));
+			break;
+		}
+
+		if (hdr->len <
+		    sizeof(struct mctp_hdr) + sizeof(struct mctp_usb_hdr)) {
+			dev_dbg(&mctp_usb->usbdev->dev,
+				"%s: short packet (hdr) %d\n",
+				__func__, hdr->len);
+			break;
+		}
+
+		if (hdr->len > skb->len) {
+			dev_dbg(&mctp_usb->usbdev->dev,
+				"%s: short packet (xfer) %d, actual %d\n",
+				__func__, hdr->len, skb->len);
+			break;
+		}
+
+		if (hdr->len < skb->len) {
+			/* more packets may follow - clone to a new
+			 * skb to use on the next iteration
+			 */
+			skb2 = skb_clone(skb, GFP_ATOMIC);
+			if (skb2) {
+				if (!skb_pull(skb2, hdr->len)) {
+					kfree_skb(skb2);
+					skb2 = NULL;
+				}
+			}
+			skb_trim(skb, hdr->len);
+		}
+
+		skb->protocol = htons(ETH_P_MCTP);
+		skb_reset_network_header(skb);
+		cb = __mctp_cb(skb);
+		cb->halen = 0;
+		netif_rx(skb);
+
+		u64_stats_update_begin(&dstats->syncp);
+		u64_stats_inc(&dstats->rx_packets);
+		u64_stats_add(&dstats->rx_bytes, skb->len);
+		u64_stats_update_end(&dstats->syncp);
+
+		skb = skb2;
+	}
+
+	if (skb)
+		kfree_skb(skb);
+
+	mctp_usb_rx_queue(mctp_usb);
+}
+
+static int mctp_usb_open(struct net_device *dev)
+{
+	struct mctp_usb *mctp_usb = netdev_priv(dev);
+
+	return mctp_usb_rx_queue(mctp_usb);
+}
+
+static int mctp_usb_stop(struct net_device *dev)
+{
+	netif_stop_queue(dev);
+	return 0;
+}
+
+static const struct net_device_ops mctp_usb_netdev_ops = {
+	.ndo_start_xmit = mctp_usb_start_xmit,
+	.ndo_open = mctp_usb_open,
+	.ndo_stop = mctp_usb_stop,
+};
+
+static void mctp_usb_netdev_setup(struct net_device *dev)
+{
+	dev->type = ARPHRD_MCTP;
+
+	dev->mtu = MCTP_USB_MTU_MIN;
+	dev->min_mtu = MCTP_USB_MTU_MIN;
+	dev->max_mtu = MCTP_USB_MTU_MAX;
+
+	dev->hard_header_len = sizeof(struct mctp_usb_hdr);
+	dev->addr_len = 0;
+	dev->flags = IFF_NOARP;
+	dev->netdev_ops = &mctp_usb_netdev_ops;
+	dev->needs_free_netdev = true;
+	dev->pcpu_stat_type = NETDEV_PCPU_STAT_DSTATS;
+}
+
+static int mctp_usb_probe(struct usb_interface *intf,
+			  const struct usb_device_id *id)
+{
+	struct usb_endpoint_descriptor *ep_in, *ep_out;
+	struct usb_host_interface *iface_desc;
+	struct net_device *netdev;
+	struct mctp_usb *dev;
+	int rc;
+
+	/* only one alternate */
+	iface_desc = intf->cur_altsetting;
+
+	rc = usb_find_common_endpoints(iface_desc, &ep_in, &ep_out, NULL, NULL);
+	if (rc) {
+		dev_err(&intf->dev, "invalid endpoints on device?\n");
+		return rc;
+	}
+
+	netdev = alloc_netdev(sizeof(*dev), "mctpusb%d", NET_NAME_ENUM,
+			      mctp_usb_netdev_setup);
+	if (!netdev)
+		return -ENOMEM;
+
+	dev = netdev_priv(netdev);
+	dev->netdev = netdev;
+	dev->usbdev = usb_get_dev(interface_to_usbdev(intf));
+	dev->intf = intf;
+	usb_set_intfdata(intf, dev);
+
+	dev->ep_in = ep_in->bEndpointAddress;
+	dev->ep_out = ep_out->bEndpointAddress;
+
+	dev->tx_urb = usb_alloc_urb(0, GFP_KERNEL);
+	dev->rx_urb = usb_alloc_urb(0, GFP_KERNEL);
+	if (!dev->tx_urb || !dev->rx_urb) {
+		rc = -ENOMEM;
+		goto err_free_urbs;
+	}
+
+	rc = register_netdev(netdev);
+	if (rc)
+		goto err_free_urbs;
+
+	return 0;
+
+err_free_urbs:
+	usb_free_urb(dev->tx_urb);
+	usb_free_urb(dev->rx_urb);
+	free_netdev(netdev);
+	return rc;
+}
+
+static void mctp_usb_disconnect(struct usb_interface *intf)
+{
+	struct mctp_usb *dev = usb_get_intfdata(intf);
+
+	unregister_netdev(dev->netdev);
+}
+
+static const struct usb_device_id mctp_usb_devices[] = {
+	{ USB_INTERFACE_INFO(USB_CLASS_MCTP, 0x0, 0x1) },
+	{ 0 },
+};
+
+static struct usb_driver mctp_usb_driver = {
+	.name		= "mctp",
+	.id_table	= mctp_usb_devices,
+	.probe		= mctp_usb_probe,
+	.disconnect	= mctp_usb_disconnect,
+};
+
+module_usb_driver(mctp_usb_driver)
+
+MODULE_LICENSE("GPL");

--- a/drivers/usb/gadget/Kconfig
+++ b/drivers/usb/gadget/Kconfig
@@ -221,6 +221,9 @@ config USB_F_PRINTER
 config USB_F_TCM
 	tristate
 
+config USB_F_MCTP
+	tristate
+
 # this first set of drivers all depend on bulk-capable hardware.
 
 config USB_CONFIGFS
@@ -505,6 +508,18 @@ config USB_CONFIGFS_F_TCM
 	  interface 0 (primary) and UAS is on alternative interface 1.
 	  Both protocols can work on USB2.0 and USB3.0.
 	  UAS utilizes the USB 3.0 feature called streams support.
+
+config USB_CONFIGFS_F_MCTP
+	bool "MCTP function"
+	depends on USB_CONFIGFS
+	select USB_F_MCTP
+	help
+	  MCTP endpoint function. This implements the device-side of a
+	  MCTP-over-USB transport, defined by DMTF DSP0283.
+
+	  This gadget driver exposes a MCTP-type network interface for
+	  MCTP packet transfer, using the kernel's MCTP core protocol
+	  support.
 
 source "drivers/usb/gadget/legacy/Kconfig"
 

--- a/drivers/usb/gadget/function/Makefile
+++ b/drivers/usb/gadget/function/Makefile
@@ -52,3 +52,5 @@ usb_f_printer-y			:= f_printer.o
 obj-$(CONFIG_USB_F_PRINTER)	+= usb_f_printer.o
 usb_f_tcm-y			:= f_tcm.o
 obj-$(CONFIG_USB_F_TCM)		+= usb_f_tcm.o
+usb_f_mctp-y			:= f_mctp.o
+obj-$(CONFIG_USB_F_MCTP)	+= usb_f_mctp.o

--- a/drivers/usb/gadget/function/f_mctp.c
+++ b/drivers/usb/gadget/function/f_mctp.c
@@ -1,0 +1,660 @@
+// SPDX-License-Identifier: GPL-2.0+
+/*
+ * f_mctp.c - USB peripheral MCTP driver
+ *
+ * Copyright (C) 2024 Code Construct Pty Ltd
+ */
+
+#include <linux/slab.h>
+#include <linux/kernel.h>
+#include <linux/device.h>
+#include <linux/module.h>
+#include <linux/usb/composite.h>
+#include <linux/skbuff.h>
+#include <linux/err.h>
+#include <linux/netdevice.h>
+#include <linux/list.h>
+
+#include <net/mctp.h>
+#include <net/pkt_sched.h>
+
+#include <linux/usb/mctp-usb.h>
+
+#include <uapi/linux/if_arp.h>
+
+#include "u_f.h"
+
+#define MCTP_USB_PREALLOC	4
+
+struct f_mctp {
+	struct usb_function	function;
+
+	struct usb_ep		*in_ep;
+	struct usb_ep		*out_ep;
+
+	struct net_device	*dev;
+
+	/* Updates to skb_free_list and the req lists are performed under
+	 * ->lock
+	 */
+	spinlock_t		lock;
+	struct sk_buff_head	skb_free_list;
+	struct list_head	rx_reqs;
+	struct list_head	tx_reqs;
+
+	struct work_struct	prealloc_work;
+};
+
+struct f_mctp_opts {
+	struct usb_function_instance	function_instance;
+};
+
+static inline struct f_mctp *func_to_mctp(struct usb_function *f)
+{
+	return container_of(f, struct f_mctp, function);
+}
+
+static struct usb_interface_descriptor mctp_usbg_intf = {
+	.bLength =		sizeof(mctp_usbg_intf),
+	.bDescriptorType =	USB_DT_INTERFACE,
+
+	.bNumEndpoints =	2,
+	.bInterfaceClass =	USB_CLASS_MCTP,
+	.bInterfaceSubClass =	0x0, /* todo: allow host-interface mode? */
+	.bInterfaceProtocol =	0x1, /* MCTP version 1 */
+	/* .iInterface = DYNAMIC */
+};
+
+/* descriptors, full speed only */
+
+static struct usb_endpoint_descriptor fs_mctp_source_desc = {
+	.bLength =		USB_DT_ENDPOINT_SIZE,
+	.bDescriptorType =	USB_DT_ENDPOINT,
+	.wMaxPacketSize =	cpu_to_le16(MCTP_USB_XFER_SIZE),
+
+	.bEndpointAddress =	USB_DIR_IN,
+	.bmAttributes =		USB_ENDPOINT_XFER_BULK,
+};
+
+static struct usb_endpoint_descriptor fs_mctp_sink_desc = {
+	.bLength =		USB_DT_ENDPOINT_SIZE,
+	.bDescriptorType =	USB_DT_ENDPOINT,
+	.wMaxPacketSize =	cpu_to_le16(MCTP_USB_XFER_SIZE),
+
+	.bEndpointAddress =	USB_DIR_OUT,
+	.bmAttributes =		USB_ENDPOINT_XFER_BULK,
+};
+
+static struct usb_descriptor_header *fs_mctp_descs[] = {
+	(struct usb_descriptor_header *) &mctp_usbg_intf,
+	(struct usb_descriptor_header *) &fs_mctp_sink_desc,
+	(struct usb_descriptor_header *) &fs_mctp_source_desc,
+	NULL,
+};
+
+/* strings */
+static struct usb_string mctp_usbg_strings[] = {
+	{ .s = "MCTP over USB" },
+	{ 0 }
+};
+
+static struct usb_gadget_strings mctp_usbg_stringtab = {
+	.language	= 0x0409,	/* en-us */
+	.strings	= mctp_usbg_strings,
+};
+
+static struct usb_gadget_strings *mctp_usbg_gadget_strings[] = {
+	&mctp_usbg_stringtab,
+	NULL,
+};
+
+static int mctp_usbg_bind(struct usb_configuration *c, struct usb_function *f)
+{
+	struct usb_composite_dev *cdev = c->cdev;
+	struct f_mctp *mctp = func_to_mctp(f);
+	int id, rc;
+
+	id = usb_interface_id(c, f);
+	if (id < 0)
+		return id;
+	mctp_usbg_intf.bInterfaceNumber = id;
+
+	id = usb_string_id(cdev);
+	if (id < 0)
+		return id;
+
+	mctp_usbg_strings[0].id = id;
+
+	mctp->in_ep = usb_ep_autoconfig(cdev->gadget, &fs_mctp_source_desc);
+	if (!mctp->in_ep) {
+		ERROR(cdev, "%s in_ep autoconfig failed\n", f->name);
+		return -ENODEV;
+	}
+
+	mctp->out_ep = usb_ep_autoconfig(cdev->gadget, &fs_mctp_sink_desc);
+	if (!mctp->out_ep) {
+		ERROR(cdev, "%s out_ep autoconfig failed\n", f->name);
+		return -ENODEV;
+	}
+
+	rc = usb_assign_descriptors(f, fs_mctp_descs, NULL, NULL, NULL);
+	if (rc) {
+		ERROR(cdev, "assign_descriptors failed %d\n", rc);
+		return rc;
+	}
+
+	DBG(cdev, "%s: in %s, out %s\n", f->name, mctp->in_ep->name,
+	     mctp->out_ep->name);
+
+	return 0;
+}
+
+static void mctp_usbg_prealloc(struct f_mctp *mctp)
+{
+	struct sk_buff_head skbs;
+	struct usb_request *req;
+	struct list_head reqs;
+	struct sk_buff *skb;
+	unsigned long flags;
+	unsigned int n_skb;
+
+	/* allocate SKBs for requests that have been consumed and don't
+	 * have an associated skb, then requeue.
+	 */
+	spin_lock_irqsave(&mctp->lock, flags);
+	list_replace_init(&mctp->rx_reqs, &reqs);
+	spin_unlock_irqrestore(&mctp->lock, flags);
+
+	list_for_each_entry(req, &reqs, list) {
+		skb = __netdev_alloc_skb(mctp->dev, MCTP_USB_XFER_SIZE,
+					 GFP_KERNEL);
+		if (!skb)
+			break;
+
+		req->buf = skb->data;
+		req->context = skb;
+		usb_ep_queue(mctp->out_ep, req, GFP_KERNEL);
+	}
+
+	/* next, allocate our pool of spare skbs */
+	n_skb = skb_queue_len_lockless(&mctp->skb_free_list);
+	__skb_queue_head_init(&skbs);
+
+	for (; n_skb < MCTP_USB_PREALLOC; n_skb++) {
+		skb = __netdev_alloc_skb(mctp->dev, MCTP_USB_XFER_SIZE,
+					 GFP_KERNEL);
+		if (!skb)
+			break;
+
+		__skb_queue_tail(&skbs, skb);
+	}
+
+	spin_lock_irqsave(&mctp->lock, flags);
+	skb_queue_splice_tail(&skbs, &mctp->skb_free_list);
+	spin_unlock_irqrestore(&mctp->lock, flags);
+}
+
+static void mctp_usbg_prealloc_work(struct work_struct *work)
+{
+	struct f_mctp *mctp = container_of(work, struct f_mctp, prealloc_work);
+
+	mctp_usbg_prealloc(mctp);
+}
+
+static int mctp_usbg_requeue(struct f_mctp *mctp, struct usb_ep *ep,
+			     struct usb_request *req)
+{
+	unsigned long flags;
+	struct sk_buff *skb;
+	int rc = 0;
+
+	req->buf = NULL;
+
+	spin_lock_irqsave(&mctp->lock, flags);
+
+	/* Do we have a preallocated skb available? if so, we can requeue
+	 * immediately; otherwise wait for the workqueue to populate.
+	 */
+	skb = __skb_dequeue(&mctp->skb_free_list);
+	if (skb) {
+		req->buf = skb->data;
+		req->context = skb;
+		rc = usb_ep_queue(ep, req, GFP_ATOMIC);
+	} else {
+		/* keep for later allocation */
+		list_add_tail(&req->list, &mctp->rx_reqs);
+	}
+
+	spin_unlock_irqrestore(&mctp->lock, flags);
+
+	schedule_work(&mctp->prealloc_work);
+
+	return rc;
+}
+
+static void mctp_usbg_handle_rx_urb(struct f_mctp *mctp,
+				    struct usb_request *req)
+{
+	struct device *dev = &mctp->function.config->cdev->gadget->dev;
+	struct pcpu_dstats *dstats = this_cpu_ptr(mctp->dev->dstats);
+	struct sk_buff *skb = req->context;
+	struct mctp_usb_hdr *hdr;
+	struct mctp_skb_cb *cb;
+	unsigned int len;
+	u16 id;
+
+	len = req->actual;
+	__skb_put(skb, len);
+
+	hdr = skb_pull_data(skb, sizeof(*hdr));
+	if (!hdr)
+		goto err;
+
+	id = le16_to_cpu(hdr->id);
+	if (id != MCTP_USB_DMTF_ID) {
+		dev_dbg(dev, "%s: invalid id %04x\n", __func__, id);
+		goto err;
+	}
+
+	if (hdr->len < sizeof(struct mctp_hdr) + sizeof(struct mctp_usb_hdr)) {
+		dev_dbg(dev, "%s: short packet (hdr) %d\n",
+			__func__, hdr->len);
+		goto err;
+	}
+
+	/* todo: multi-packet transfers */
+	if (hdr->len < skb->len) {
+		dev_dbg(dev, "%s: short packet (xfer) %d, actual %d\n",
+			__func__, hdr->len, skb->len);
+		goto err;
+	}
+
+	skb->protocol = htons(ETH_P_MCTP);
+	skb_reset_network_header(skb);
+	cb = __mctp_cb(skb);
+	cb->halen = 0;
+	netif_rx(skb);
+
+	u64_stats_update_begin(&dstats->syncp);
+	u64_stats_inc(&dstats->rx_packets);
+	u64_stats_add(&dstats->rx_bytes, len);
+	u64_stats_update_end(&dstats->syncp);
+
+	return;
+
+err:
+	/* todo: return to free list */
+	kfree_skb(skb);
+}
+
+static void mctp_usbg_out_ep_complete(struct usb_ep *ep,
+				      struct usb_request *req)
+{
+	struct f_mctp *mctp = ep->driver_data;
+	struct usb_composite_dev *cdev = mctp->function.config->cdev;
+	int rc;
+
+	switch (req->status) {
+	case 0:
+		mctp_usbg_handle_rx_urb(mctp, req);
+
+		/* re-queue out request */
+		rc = mctp_usbg_requeue(mctp, ep, req);
+		if (rc) {
+			WARNING(cdev, "%s: unable to re-queue out req\n",
+				__func__);
+			usb_ep_free_request(ep, req);
+		}
+
+		break;
+
+	case -ECONNABORTED:
+	case -ECONNRESET:
+	case -ESHUTDOWN:
+		kfree_skb(req->context);
+		usb_ep_free_request(ep, req);
+		break;
+
+	default:
+		WARNING(cdev, "%s: invalid status %d?", __func__, req->status);
+		usb_ep_free_request(ep, req);
+	}
+}
+
+static void mctp_usbg_in_ep_complete(struct usb_ep *ep,
+				     struct usb_request *req)
+{
+	struct f_mctp *mctp = ep->driver_data;
+	struct usb_composite_dev *cdev = mctp->function.config->cdev;
+	struct sk_buff *skb = req->context;
+	unsigned long flags;
+
+	kfree_skb(skb);
+	req->context = NULL;
+	req->buf = NULL;
+
+	/* todo: tx stats */
+
+	switch (req->status) {
+	case 0:
+		spin_lock_irqsave(&mctp->lock, flags);
+		if (list_empty(&mctp->tx_reqs))
+			netif_start_queue(mctp->dev);
+		list_add(&req->list, &mctp->tx_reqs);
+		spin_unlock_irqrestore(&mctp->lock, flags);
+		break;
+	case -ECONNABORTED:
+	case -ECONNRESET:
+	case -ESHUTDOWN:
+		usb_ep_free_request(ep, req);
+		break;
+	default:
+		WARNING(cdev, "%s: invalid status %d?", __func__, req->status);
+		usb_ep_free_request(ep, req);
+	}
+}
+
+static int mctp_usbg_enable_ep(struct usb_gadget *gadget, struct f_mctp *mctp,
+			       struct usb_ep *ep)
+{
+	int rc;
+
+	rc = config_ep_by_speed(gadget, &mctp->function, ep);
+	if (rc)
+		return rc;
+
+	rc = usb_ep_enable(ep);
+	if (rc)
+		return rc;
+
+	ep->driver_data = mctp;
+
+	return 0;
+}
+
+static int mctp_usbg_enable(struct usb_composite_dev *cdev, struct f_mctp *mctp)
+{
+	struct usb_request *out_req, *in_req;
+	unsigned long flags;
+	struct sk_buff *skb;
+	int rc;
+
+	rc = mctp_usbg_enable_ep(cdev->gadget, mctp, mctp->out_ep);
+	if (rc) {
+		ERROR(cdev, "%s: out ep enable failed %d\n", __func__, rc);
+		return rc;
+	}
+
+	rc = mctp_usbg_enable_ep(cdev->gadget, mctp, mctp->in_ep);
+	if (rc) {
+		ERROR(cdev, "%s: in ep enable failed %d\n", __func__, rc);
+		goto err_disable_out;
+	}
+
+	/* todo: just one out queued req for now */
+	out_req = alloc_ep_req(mctp->out_ep, MCTP_USB_XFER_SIZE);
+	if (!out_req) {
+		ERROR(cdev, "%s: out req alloc failed\n", __func__);
+		goto err_disable_in;
+	}
+
+	spin_lock_irqsave(&mctp->lock, flags);
+	skb = __skb_dequeue(&mctp->skb_free_list);
+	spin_unlock_irqrestore(&mctp->lock, flags);
+
+	if (!skb)
+		skb = netdev_alloc_skb(mctp->dev, MCTP_USB_XFER_SIZE);
+
+	if (!skb)
+		goto err_free_req;
+
+	out_req->context = skb;
+	out_req->buf = skb->data;
+	out_req->complete = mctp_usbg_out_ep_complete;
+
+	rc = usb_ep_queue(mctp->out_ep, out_req, GFP_ATOMIC);
+	if (rc) {
+		ERROR(cdev, "%s: out req queue failed %d\b", __func__, rc);
+		goto err_free_skb;
+	}
+
+	/* todo: and just one in the in queue too */
+	in_req = usb_ep_alloc_request(mctp->in_ep, GFP_ATOMIC);
+	if (!in_req) {
+		ERROR(cdev, "%s: out req alloc failed\n", __func__);
+		goto err_disable_in;
+	}
+	in_req->complete = mctp_usbg_in_ep_complete;
+
+	spin_lock_irqsave(&mctp->lock, flags);
+	list_add(&in_req->list, &mctp->tx_reqs);
+	spin_unlock_irqrestore(&mctp->lock, flags);
+
+	return 0;
+
+
+err_free_skb:
+	kfree_skb(skb);
+err_free_req:
+	free_ep_req(mctp->out_ep, out_req);
+err_disable_in:
+	usb_ep_disable(mctp->in_ep);
+err_disable_out:
+	usb_ep_disable(mctp->out_ep);
+
+	return rc;
+}
+
+static netdev_tx_t mctp_usbg_start_xmit(struct sk_buff *skb,
+				       struct net_device *dev)
+{
+	struct f_mctp *mctp = netdev_priv(dev);
+	struct pcpu_dstats *dstats = this_cpu_ptr(mctp->dev->dstats);
+	struct mctp_usb_hdr *hdr;
+	struct usb_request *req;
+	unsigned long flags;
+	unsigned int plen;
+
+	if (skb->len + sizeof(*hdr) > MCTP_USB_XFER_SIZE)
+		goto drop;
+
+	spin_lock_irqsave(&mctp->lock, flags);
+	req = list_first_entry_or_null(&mctp->tx_reqs, struct usb_request, list);
+	if (req)
+		list_del(&req->list);
+	if (list_empty(&req->list))
+		netif_stop_queue(dev);
+	spin_unlock_irqrestore(&mctp->lock, flags);
+
+	if (!req) {
+		netdev_err(dev, "no tx reqs available!\n");
+		goto drop;
+	}
+
+	plen = skb->len;
+	hdr = skb_push(skb, sizeof(*hdr));
+	hdr->id = cpu_to_le16(MCTP_USB_DMTF_ID);
+	hdr->rsvd = 0;
+	hdr->len = plen + sizeof(*hdr);
+
+	/* todo: just one skb per transfer.. */
+	req->context = skb;
+	req->buf = skb->data;
+	req->length = skb->len;
+
+	usb_ep_queue(mctp->in_ep, req, GFP_ATOMIC);
+
+	u64_stats_update_begin(&dstats->syncp);
+	u64_stats_inc(&dstats->tx_packets);
+	u64_stats_add(&dstats->tx_bytes, plen);
+	u64_stats_update_end(&dstats->syncp);
+
+	return NETDEV_TX_OK;
+
+drop:
+	kfree_skb(skb);
+	u64_stats_update_begin(&dstats->syncp);
+	u64_stats_inc(&dstats->tx_drops);
+	u64_stats_update_end(&dstats->syncp);
+	return NETDEV_TX_OK;
+}
+
+static int mctp_usbg_open(struct net_device *net)
+{
+	return 0;
+}
+
+static int mctp_usbg_stop(struct net_device *net)
+{
+	return 0;
+}
+
+static const struct net_device_ops mctp_usbg_netdev_ops = {
+	.ndo_open = mctp_usbg_open,
+	.ndo_stop = mctp_usbg_stop,
+	.ndo_start_xmit = mctp_usbg_start_xmit,
+};
+
+static void __mctp_usbg_disable(struct f_mctp *mctp)
+{
+	usb_ep_disable(mctp->in_ep);
+	usb_ep_disable(mctp->out_ep);
+}
+
+static void mctp_usbg_disable(struct usb_function *f)
+{
+	struct f_mctp *mctp = func_to_mctp(f);
+
+	__mctp_usbg_disable(mctp);
+}
+
+static int mctp_usbg_set_alt(struct usb_function *f,
+			     unsigned intf, unsigned alt)
+{
+	struct usb_composite_dev *cdev = f->config->cdev;
+	struct f_mctp *mctp = func_to_mctp(f);
+
+	__mctp_usbg_disable(mctp);
+	return mctp_usbg_enable(cdev, mctp);
+}
+
+static void mctp_usbg_free_func(struct usb_function *f)
+{
+	struct f_mctp *mctp = func_to_mctp(f);
+
+	kfree(mctp);
+}
+
+static void mctp_usbg_netdev_setup(struct net_device *dev)
+{
+	dev->type = ARPHRD_MCTP;
+
+	dev->mtu = MCTP_USB_MTU_MIN;
+	dev->min_mtu = MCTP_USB_MTU_MIN;
+	dev->max_mtu = MCTP_USB_MTU_MAX;
+
+	dev->hard_header_len = 0;
+	dev->addr_len = 0;
+	dev->tx_queue_len = DEFAULT_TX_QUEUE_LEN;
+	dev->flags = IFF_NOARP;
+	dev->netdev_ops = &mctp_usbg_netdev_ops;
+	dev->needs_free_netdev = true;
+	dev->pcpu_stat_type = NETDEV_PCPU_STAT_DSTATS;
+}
+
+static struct usb_function
+*mctp_usbg_alloc_func(struct usb_function_instance *fi)
+{
+	struct f_mctp_opts *opts;
+	struct net_device *dev;
+	struct f_mctp *mctp;
+	int rc;
+
+	opts = container_of(fi, struct f_mctp_opts, function_instance);
+
+	dev = alloc_netdev(sizeof(*mctp), "mctpusbg%d", NET_NAME_ENUM,
+			    mctp_usbg_netdev_setup);
+	if (!dev)
+		return ERR_PTR(-ENOMEM);
+
+	mctp = netdev_priv(dev);
+	mctp->dev = dev;
+
+	spin_lock_init(&mctp->lock);
+	INIT_LIST_HEAD(&mctp->rx_reqs);
+	INIT_LIST_HEAD(&mctp->tx_reqs);
+	__skb_queue_head_init(&mctp->skb_free_list);
+	INIT_WORK(&mctp->prealloc_work, mctp_usbg_prealloc_work);
+
+	mctp->function.name = "mctp";
+	mctp->function.bind = mctp_usbg_bind;
+	mctp->function.set_alt = mctp_usbg_set_alt;
+	mctp->function.disable = mctp_usbg_disable;
+	mctp->function.strings = mctp_usbg_gadget_strings;
+	mctp->function.free_func = mctp_usbg_free_func;
+
+	/* this will allocate our first pool of out (rx) skbs */
+	mctp_usbg_prealloc(mctp);
+
+	rc = register_netdev(dev);
+	if (rc) {
+		free_netdev(dev);
+		return ERR_PTR(rc);
+	}
+
+	return &mctp->function;
+}
+
+static struct f_mctp_opts *to_f_mctp_opts(struct config_item *item)
+{
+	return container_of(to_config_group(item), struct f_mctp_opts,
+			    function_instance.group);
+}
+
+static void mctp_usbg_attr_release(struct config_item *item)
+{
+	struct f_mctp_opts *opts = to_f_mctp_opts(item);
+
+	usb_put_function_instance(&opts->function_instance);
+}
+
+static struct configfs_item_operations mctp_usbg_item_ops = {
+	.release = mctp_usbg_attr_release,
+};
+
+static struct configfs_attribute *mctp_usbg_attrs[] = {
+	NULL,
+};
+
+static const struct config_item_type mctp_usbg_func_type = {
+	.ct_item_ops    = &mctp_usbg_item_ops,
+	.ct_attrs	= mctp_usbg_attrs,
+	.ct_owner       = THIS_MODULE,
+};
+
+static void mctp_usbg_free_instance(struct usb_function_instance *fi)
+{
+	struct f_mctp_opts *opts;
+
+	opts = container_of(fi, struct f_mctp_opts, function_instance);
+	kfree(opts);
+}
+
+static struct usb_function_instance *mctp_usbg_alloc_instance(void)
+{
+	struct f_mctp_opts *opts;
+
+	opts = kzalloc(sizeof(*opts), GFP_KERNEL);
+	if (!opts)
+		return ERR_PTR(-ENOMEM);
+
+	opts->function_instance.free_func_inst = mctp_usbg_free_instance;
+
+	config_group_init_type_name(&opts->function_instance.group, "",
+				    &mctp_usbg_func_type);
+
+	return &opts->function_instance;
+}
+
+DECLARE_USB_FUNCTION_INIT(mctp, mctp_usbg_alloc_instance, mctp_usbg_alloc_func);
+MODULE_LICENSE("GPL");

--- a/drivers/usb/gadget/function/f_mctp.c
+++ b/drivers/usb/gadget/function/f_mctp.c
@@ -43,10 +43,15 @@ struct f_mctp {
 	struct list_head	tx_reqs;
 
 	struct work_struct	prealloc_work;
+
+	unsigned int		tx_batch_delay;
+	struct sk_buff_head	tx_batch;
+	struct delayed_work	tx_batch_work;
 };
 
 struct f_mctp_opts {
 	struct usb_function_instance	function_instance;
+	unsigned int			tx_batch_delay;
 };
 
 static inline struct f_mctp *func_to_mctp(struct usb_function *f)
@@ -199,6 +204,102 @@ static void mctp_usbg_prealloc_work(struct work_struct *work)
 	struct f_mctp *mctp = container_of(work, struct f_mctp, prealloc_work);
 
 	mctp_usbg_prealloc(mctp);
+}
+
+static unsigned int __mctp_usbg_tx_batch_len(struct f_mctp *mctp)
+	__must_hold(&mctp->lock)
+{
+	struct sk_buff_head *batch = &mctp->tx_batch;
+	unsigned int len = 0;
+	struct sk_buff *skb;
+
+	for (skb = __skb_peek(batch); skb; skb = skb_peek_next(skb, batch))
+		len += skb->len;
+
+	return len;
+}
+
+/* skb already has USB headers, may contain multiple packets */
+static int __mctp_usbg_tx(struct f_mctp *mctp, struct sk_buff *skb)
+	__must_hold(&mctp->lock)
+{
+	struct net_device *dev = mctp->dev;
+	struct usb_request *req;
+
+	req = list_first_entry_or_null(&mctp->tx_reqs, struct usb_request, list);
+	if (req)
+		list_del(&req->list);
+	if (list_empty(&req->list))
+		netif_stop_queue(dev);
+
+	if (!req) {
+		netdev_err(dev, "no tx reqs available!\n");
+		return -1;
+	}
+
+	req->context = skb;
+	req->buf = skb->data;
+	req->length = skb->len;
+
+	usb_ep_queue(mctp->in_ep, req, GFP_ATOMIC);
+
+	return 0;
+}
+
+static void __mctp_usbg_batch_tx(struct f_mctp *mctp)
+	__must_hold(&mctp->lock)
+{
+	unsigned int i = 1, batch_len = 0;
+	struct sk_buff *skb, *skb2;
+	bool realloc = false;
+
+	batch_len = __mctp_usbg_tx_batch_len(mctp);
+
+	skb = __skb_dequeue(&mctp->tx_batch);
+	if (!skb)
+		return;
+
+	/* if the first skb can't hold the batch, allocate a new one */
+	if (batch_len - skb->len > skb_tailroom(skb)) {
+		realloc = true;
+		skb2 = skb;
+		skb = netdev_alloc_skb(mctp->dev, batch_len);
+		if (!skb) {
+			netdev_warn_once(mctp->dev, "batch alloc failed\n");
+			__skb_queue_purge(&mctp->tx_batch);
+			return;
+		}
+		__skb_put_data(skb, skb2->data, skb2->len);
+		consume_skb(skb2);
+	}
+
+	while ((skb2 = __skb_dequeue(&mctp->tx_batch)) != NULL) {
+		__skb_put_data(skb, skb2->data, skb2->len);
+		consume_skb(skb2);
+		i++;
+	}
+
+	netdev_dbg(mctp->dev, "batch tx: %d for len %d%s. skb len %d\n",
+		   i, batch_len, realloc ? ", realloced" : "", skb->len);
+
+	__mctp_usbg_tx(mctp, skb);
+}
+
+static void mctp_usbg_batch_tx(struct f_mctp *mctp)
+{
+	unsigned long flags;
+
+	spin_lock_irqsave(&mctp->lock, flags);
+	__mctp_usbg_batch_tx(mctp);
+	spin_unlock_irqrestore(&mctp->lock, flags);
+}
+
+static void mctp_usbg_batch_tx_work(struct work_struct *work)
+{
+	struct f_mctp *mctp = container_of(work, struct f_mctp,
+					   tx_batch_work.work);
+
+	mctp_usbg_batch_tx(mctp);
 }
 
 static int mctp_usbg_requeue(struct f_mctp *mctp, struct usb_ep *ep,
@@ -451,25 +552,11 @@ static netdev_tx_t mctp_usbg_start_xmit(struct sk_buff *skb,
 	struct f_mctp *mctp = netdev_priv(dev);
 	struct pcpu_dstats *dstats = this_cpu_ptr(mctp->dev->dstats);
 	struct mctp_usb_hdr *hdr;
-	struct usb_request *req;
 	unsigned long flags;
 	unsigned int plen;
 
 	if (skb->len + sizeof(*hdr) > MCTP_USB_XFER_SIZE)
 		goto drop;
-
-	spin_lock_irqsave(&mctp->lock, flags);
-	req = list_first_entry_or_null(&mctp->tx_reqs, struct usb_request, list);
-	if (req)
-		list_del(&req->list);
-	if (list_empty(&req->list))
-		netif_stop_queue(dev);
-	spin_unlock_irqrestore(&mctp->lock, flags);
-
-	if (!req) {
-		netdev_err(dev, "no tx reqs available!\n");
-		goto drop;
-	}
 
 	plen = skb->len;
 	hdr = skb_push(skb, sizeof(*hdr));
@@ -477,12 +564,23 @@ static netdev_tx_t mctp_usbg_start_xmit(struct sk_buff *skb,
 	hdr->rsvd = 0;
 	hdr->len = plen + sizeof(*hdr);
 
-	/* todo: just one skb per transfer.. */
-	req->context = skb;
-	req->buf = skb->data;
-	req->length = skb->len;
+	spin_lock_irqsave(&mctp->lock, flags);
+	if (!mctp->tx_batch_delay) {
+		/* direct tx */
+		__mctp_usbg_tx(mctp, skb);
+	} else {
+		unsigned int batch_len;
 
-	usb_ep_queue(mctp->in_ep, req, GFP_ATOMIC);
+		batch_len = __mctp_usbg_tx_batch_len(mctp);
+		if (batch_len + skb->len > MCTP_USB_XFER_SIZE)
+			__mctp_usbg_batch_tx(mctp);
+
+		__skb_queue_head(&mctp->tx_batch, skb);
+
+		schedule_delayed_work(&mctp->tx_batch_work,
+				      msecs_to_jiffies(mctp->tx_batch_delay));
+	}
+	spin_unlock_irqrestore(&mctp->lock, flags);
 
 	u64_stats_update_begin(&dstats->syncp);
 	u64_stats_inc(&dstats->tx_packets);
@@ -579,12 +677,15 @@ static struct usb_function
 
 	mctp = netdev_priv(dev);
 	mctp->dev = dev;
+	mctp->tx_batch_delay = opts->tx_batch_delay;
 
 	spin_lock_init(&mctp->lock);
 	INIT_LIST_HEAD(&mctp->rx_reqs);
 	INIT_LIST_HEAD(&mctp->tx_reqs);
 	__skb_queue_head_init(&mctp->skb_free_list);
+	__skb_queue_head_init(&mctp->tx_batch);
 	INIT_WORK(&mctp->prealloc_work, mctp_usbg_prealloc_work);
+	INIT_DELAYED_WORK(&mctp->tx_batch_work, mctp_usbg_batch_tx_work);
 
 	mctp->function.name = "mctp";
 	mctp->function.bind = mctp_usbg_bind;
@@ -622,7 +723,32 @@ static struct configfs_item_operations mctp_usbg_item_ops = {
 	.release = mctp_usbg_attr_release,
 };
 
+static ssize_t mctp_usbg_tx_batch_delay_store(struct config_item *item,
+					      const char *page, size_t count)
+{
+	struct f_mctp_opts *opts = to_f_mctp_opts(item);
+	unsigned int tmp;
+	int rc;
+
+	rc = kstrtouint(page, 0, &tmp);
+	if (!rc)
+		opts->tx_batch_delay = tmp;
+
+	return rc;
+}
+
+static ssize_t mctp_usbg_tx_batch_delay_show(struct config_item *item,
+					     char *page)
+{
+	struct f_mctp_opts *opts = to_f_mctp_opts(item);
+
+	return sprintf(page, "%u\n", opts->tx_batch_delay);
+}
+
+CONFIGFS_ATTR(mctp_usbg_, tx_batch_delay);
+
 static struct configfs_attribute *mctp_usbg_attrs[] = {
+	&mctp_usbg_attr_tx_batch_delay,
 	NULL,
 };
 

--- a/include/linux/usb/mctp-usb.h
+++ b/include/linux/usb/mctp-usb.h
@@ -1,0 +1,27 @@
+/* SPDX-License-Identifier: GPL-2.0+ */
+/*
+ * mctp-usb.h - MCTP USB transport binding: common definitions.
+ *
+ * These are shared between the host and gadget drivers.
+ *
+ * Copyright (C) 2024 Code Construct Pty Ltd
+ */
+
+#ifndef __LINUX_USB_MCTP_USB_H
+#define __LINUX_USB_MCTP_USB_H
+
+#include <linux/types.h>
+
+struct mctp_usb_hdr {
+	__le16	id;
+	__u8	rsvd;
+	__u8	len;
+} __packed;
+
+#define MCTP_USB_XFER_SIZE	512
+#define MCTP_USB_BTU		68
+#define MCTP_USB_MTU_MIN	MCTP_USB_BTU
+#define MCTP_USB_MTU_MAX	(U8_MAX - sizeof(struct mctp_usb_hdr))
+#define MCTP_USB_DMTF_ID	0x1ab4
+
+#endif /*  __LINUX_USB_MCTP_USB_H */

--- a/include/linux/usb/mctp-usb.h
+++ b/include/linux/usb/mctp-usb.h
@@ -13,7 +13,7 @@
 #include <linux/types.h>
 
 struct mctp_usb_hdr {
-	__le16	id;
+	__be16	id;
 	__u8	rsvd;
 	__u8	len;
 } __packed;

--- a/include/uapi/linux/usb/ch9.h
+++ b/include/uapi/linux/usb/ch9.h
@@ -327,6 +327,7 @@ struct usb_device_descriptor {
 #define USB_CLASS_AUDIO_VIDEO		0x10
 #define USB_CLASS_BILLBOARD		0x11
 #define USB_CLASS_USB_TYPE_C_BRIDGE	0x12
+#define USB_CLASS_MCTP			0x14
 #define USB_CLASS_MISC			0xef
 #define USB_CLASS_APP_SPEC		0xfe
 #define USB_CLASS_VENDOR_SPEC		0xff


### PR DESCRIPTION
Fixes the following:

* Endian-ness of the MCTP USB binding header (DMTF ID)
* Getting the binding header from the URB.

Tested:
Tested on a hardware that supports MCTP over USB.
MCTP Control commands work fine after fixes.